### PR TITLE
Update BlockNewOutlookScripts

### DIFF
--- a/BlockNewOutlookScripts
+++ b/BlockNewOutlookScripts
@@ -96,12 +96,11 @@ Run as user - No
 64 bit - Yes or No
 
 #Detect
-
-$NewOutlookApp =  Get-AppxPackage | Sort-Object Name | Select Name | where { $_.Name -match "Microsoft.OutlookForWindows"}
+$NewOutlookApp = Get-AppxPackage -Name "*Microsoft.OutlookForWindows*"
 
 if ($NewOutlookApp.Name -match "Microsoft.OutlookForWindows")
 {
-    Write-Output $MyApp.Name
+    Write-Output $NewOutlookApp.PackageFullname
     Write-Output "New Outlook is installed on this computer."
     Exit 1
 }
@@ -112,14 +111,14 @@ else
 }
 
 
-Remediation
+#Remediation
 
 $NewOutlookApp = Get-AppxPackage -Name "*Microsoft.OutlookForWindows*"
 
 if ($NewOutlookApp)
 {
     Write-Output "New Outlook is installed on this computer."
-    Remove-AppxPackage -Package $NewOutlookApp.packageFullname -AllUsers -Verbose
+    Remove-AppxPackage -Package $NewOutlookApp.PackageFullname -AllUsers -Verbose
     Exit 0
 }
 else


### PR DESCRIPTION
- Fixed reference to $MyApp, which was never declared
- Fixed missing "#" before Remediation
- Fixed reference to PackageFullName (previously not capitalised, not huge deal but worthwhile)